### PR TITLE
Wait / sync  primitives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PYTHON = python
+ARGS ?=
 
 coverage:
 	$(PYTHON) -m coverage run tests.py
@@ -10,6 +11,10 @@ install:
 
 test:
 	$(PYTHON) tests.py
+
+# E.g. make test-by-name ARGS=tests.TestReloadConf.test_wait_timeout
+test-by-name:
+	$(PYTHON) -m unittest -v $(ARGS)
 
 lint:
 	$(PYTHON) -m flake8 reloadconf

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,31 @@
+PYTHON = python
+
 coverage:
-	coverage run tests.py
-	coverage html
+	$(PYTHON) -m coverage run tests.py
+	$(PYTHON) -m coverage html
 	firefox htmlcov/index.html
 
+install:
+	$(PYTHON) setup.py develop
+
 test:
-	python tests.py
+	$(PYTHON) tests.py
 
 lint:
-	flake8 reloadconf
+	$(PYTHON) -m flake8 reloadconf
 
 dependencies:
-	pip install -r requirements.txt
-	pip install coveralls
-	pip install flake8
-	pip install coverage
+	$(PYTHON) -m pip install -r requirements.txt
+	$(PYTHON) -m pip install coveralls
+	$(PYTHON) -m pip install flake8
+	$(PYTHON) -m pip install coverage
 
 travis:
-	flake8 reloadconf
-	coverage run tests.py
+	$(PYTHON) -m flake8 reloadconf
+	$(PYTHON) -m coverage run tests.py
 
 coveralls:
-	coveralls -v
+	$(PYTHON) -m coveralls -v
 
 clean:
 	rm -rf dist/ *.egg-info htmlcov .coverage

--- a/reloadconf/__init__.py
+++ b/reloadconf/__init__.py
@@ -78,11 +78,6 @@ class ReloadConf(object):
         self.wait_for_path = wait_for_path
         self.wait_for_sock = wait_for_sock
         self.wait_timeout = wait_timeout
-        if self.wait_timeout and isinstance(self.wait_timeout, str):
-            if '.' in self.wait_timeout:
-                self.wait_timeout = float(self.wait_timeout)
-            else:
-                self.wait_timeout = int(self.wait_timeout)
         self.chown, self.chmod = self._setup_permissions(chown, chmod)
         # Extract names for use later.
         self.watch_names = [basename(f) for f in self.config]
@@ -222,15 +217,12 @@ class ReloadConf(object):
                              self.wait_for_path, self.wait_timeout))
 
     def _wait_for_sock(self):
-        host, port = self.wait_for_sock.split(':')
-        port = int(port)
-        addr = (host, port)
         err = None
         giveup_at = time.time() + int(self.wait_timeout)
         while time.time() <= giveup_at:
             s = socket.socket()
             try:
-                s.connect(addr)
+                s.connect(self.wait_for_sock)
             except Exception as _:
                 err = _
                 time.sleep(0.1)

--- a/reloadconf/__init__.py
+++ b/reloadconf/__init__.py
@@ -68,6 +68,11 @@ class ReloadConf(object):
         self.wait_for_path = wait_for_path
         self.wait_for_sock = wait_for_sock
         self.wait_timeout = wait_timeout
+        if self.wait_timeout and isinstance(self.wait_timeout, str):
+            if '.' in self.wait_timeout:
+                self.wait_timeout = float(self.wait_timeout)
+            else:
+                self.wait_timeout = int(self.wait_timeout)
         # Extract names for use later.
         self.watch_names = [basename(f) for f in self.config]
         # The process (once started).
@@ -102,7 +107,7 @@ class ReloadConf(object):
         return self.process is not None and self.process.poll() is None
 
     def _wait_for_path(self):
-        giveup_at = time.time() + int(self.wait_timeout)
+        giveup_at = time.time() + self.wait_timeout
         while time.time() <= giveup_at:
             if os.path.exists(self.wait_for_path):
                 return

--- a/reloadconf/__init__.py
+++ b/reloadconf/__init__.py
@@ -57,7 +57,7 @@ class ReloadConf(object):
     """
 
     def __init__(self, watch, config, command, reload=None, test=None,
-                 wait_for_file=None, wait_for_socket=None, wait_timeout=None):
+                 wait_for_path=None, wait_for_sock=None, wait_timeout=None):
         if isinstance(config, str):
             config = (config,)
         self.watch = watch
@@ -65,8 +65,8 @@ class ReloadConf(object):
         self.command = command
         self.reload = reload
         self.test = test
-        self.wait_for_file = wait_for_file
-        self.wait_for_socket = wait_for_socket
+        self.wait_for_path = wait_for_path
+        self.wait_for_sock = wait_for_sock
         self.wait_timeout = wait_timeout
         # Extract names for use later.
         self.watch_names = [basename(f) for f in self.config]
@@ -101,17 +101,17 @@ class ReloadConf(object):
         """Return False if command is dead, otherwise True."""
         return self.process is not None and self.process.poll() is None
 
-    def _wait_for_file(self):
+    def _wait_for_path(self):
         giveup_at = time.time() + int(self.wait_timeout)
         while time.time() <= giveup_at:
-            if os.path.exists(self.wait_for_file):
+            if os.path.exists(self.wait_for_path):
                 return
             time.sleep(0.1)
         raise RuntimeError("file %r still does not exist after %s secs" % (
-                           self.wait_for_file, self.wait_timeout))
+                           self.wait_for_path, self.wait_timeout))
 
-    def _wait_for_socket(self):
-        host, port = self.wait_for_socket.split(':')
+    def _wait_for_sock(self):
+        host, port = self.wait_for_sock.split(':')
         port = int(port)
         addr = (host, port)
         err = None
@@ -128,13 +128,13 @@ class ReloadConf(object):
             finally:
                 s.close()
         raise RuntimeError("can't connect to %s after %s secs; reason: %r" % (
-                           self.wait_for_socket, self.wait_timeout, err))
+                           self.wait_for_sock, self.wait_timeout, err))
 
     def wait_for_stuff(self):
-        if self.wait_for_file:
-            self._wait_for_file()
-        if self.wait_for_socket:
-            self._wait_for_socket()
+        if self.wait_for_path:
+            self._wait_for_path()
+        if self.wait_for_sock:
+            self._wait_for_sock()
 
     def poll(self):
         """Processing loop."""

--- a/reloadconf/__init__.py
+++ b/reloadconf/__init__.py
@@ -212,6 +212,8 @@ class ReloadConf(object):
             return
 
         assert isinstance(timeout, (float, int)), 'Invalid timeout'
+        assert timeout > 0, 'Invalid timeout'
+
         assert isinstance(path, str), 'Invalid path'
 
         give_up_at = time.time() + timeout
@@ -229,6 +231,8 @@ class ReloadConf(object):
             return
 
         assert isinstance(timeout, (float, int)), 'Invalid timeout'
+        assert timeout > 0, 'Invalid timeout'
+
         assert len(addr) == 2, 'Invalid address'
         assert isinstance(addr[0], str), 'Invalid host'
         assert isinstance(addr[1], int), 'Invalid port'

--- a/reloadconf/__init__.py
+++ b/reloadconf/__init__.py
@@ -19,6 +19,7 @@ from hashlib import md5
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
 DEVNULL = open(os.devnull, 'w')
+DEFAULT_TIMEOUT = 5
 
 
 class TimeoutExpired(Exception):
@@ -76,7 +77,7 @@ class ReloadConf(object):
         self.chmod = chmod
         self.wait_for_path = wait_for_path
         self.wait_for_sock = wait_for_sock
-        self.wait_timeout = wait_timeout
+        self.wait_timeout = wait_timeout or DEFAULT_TIMEOUT
         if self.wait_timeout and isinstance(self.wait_timeout, str):
             if '.' in self.wait_timeout:
                 self.wait_timeout = float(self.wait_timeout)
@@ -250,7 +251,6 @@ class ReloadConf(object):
 
             if self.chmod is not None:
                 os.chmod(dst, self.chmod)
-
 
     def test_and_swap(self, config):
         """Backup old config, write new config, test config, HUP or restore."""

--- a/reloadconf/__init__.py
+++ b/reloadconf/__init__.py
@@ -239,8 +239,9 @@ class ReloadConf(object):
             finally:
                 s.close()
 
-        raise TimeoutExpired("can't connect to %s after %s secs; reason: %r" % (
-                             addr, timeout, err))
+        raise TimeoutExpired(
+            "can't connect to %s after %s secs; reason: %r" % (addr, timeout,
+                                                               err))
 
     def get_config_files(self):
         """Use polling method to enumerate files in watch dir."""

--- a/reloadconf/__init__.py
+++ b/reloadconf/__init__.py
@@ -211,6 +211,9 @@ class ReloadConf(object):
         if path is None:
             return
 
+        assert isinstance(timeout, (float, int)), 'Invalid timeout'
+        assert isinstance(path, str), 'Invalid path'
+
         give_up_at = time.time() + timeout
 
         while time.time() <= give_up_at:
@@ -224,6 +227,12 @@ class ReloadConf(object):
     def wait_for_sock(self, addr, timeout):
         if addr is None:
             return
+
+        assert isinstance(timeout, (float, int)), 'Invalid timeout'
+        assert len(addr) == 2, 'Invalid address'
+        assert isinstance(addr[0], str), 'Invalid host'
+        assert isinstance(addr[1], int), 'Invalid port'
+        assert 0 < addr[1] < 65536, 'Invalid port'
 
         err, give_up_at = None, time.time() + int(timeout)
 

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -20,15 +20,17 @@ def validate_opts(opts):
     assert opts.get('command', '').strip(), "empty command opt"
     assert opts.get('watch', '').strip(), "empty watch opt"
     # others
-    addr = opts.get('wait_for_socket')
+    addr = opts.get('wait_for_sock')
     if addr:
-        assert addr.count(':') == 1, addr
+        assert addr.count(':') == 1, "invalid address %r" % addr
         host, port = addr.split(':')
-        assert int(port) > 0, addr
-        assert int(port) < 65536, addr
+        assert port.isdigit(), "invalid port" % port
+        assert int(port) > 0, "invalid port %r" % port
+        assert int(port) < 65536, "invalid port %r" % port
     timeout = opts.get('wait_timeout')
     if timeout:
-        assert int(timeout) > 0, timeout
+        assert timeout.isdigit(), "invalid timeout %r" % timeout
+        assert int(timeout) > 0, "invalid timeout %r" % timeout
 
 
 def main(opt):
@@ -37,8 +39,8 @@ def main(opt):
 
     Usage:
         reloadconf --command=<cmd> --watch=<dir> (--config=<file> ...)
-                   [--reload=<cmd> --test=<cmd> --wait-for-file=<file>
-                    --wait-for-socket=<host:port> --wait-timeout=<secs> --debug]
+                   [--reload=<cmd> --test=<cmd> --wait-for-path=<file>
+                    --wait-for-sock=<host:port> --wait-timeout=<secs> --debug]
 
     Options:
         --command=<cmd>  The program to run when configuration is valid.
@@ -47,9 +49,9 @@ def main(opt):
         --reload=<cmd>   The command to reload configuration (defaults to HUP
                          signal).
         --test=<cmd>     The command to test configuration.
-        --wait-for-file=<file>
+        --wait-for-path=<file>
                          Delay start until file or directory appears on disk.
-        --wait-for-socket=<host:port>
+        --wait-for-sock=<host:port>
                          Delay start until connection succeeds.
         --wait-timeout=<secs>
                          Timeout for wait-* commands [default: 5].

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -58,7 +58,7 @@ def main(argv):
         --chown=<user,group>
             The user and (optionally) group to chown config files to before
             starting service.
-        --chmod=<mode> 
+        --chmod=<mode>
             Mode to set config files to before starting service.
         --inotify
             Use inotify instead of polling.

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -30,6 +30,12 @@ def main(opt):
         --reload=<cmd>   The command to reload configuration (defaults to HUP
                          signal).
         --test=<cmd>     The command to test configuration.
+        --wait-for-file=<file>
+                         Delay start until file appears on disk.
+        --wait-for-socket=<host:port>
+                         Delay start until connection succeeds.
+        --wait-timeout=<secs>
+                         Timeout for wait-* commands [default: 5].
         --debug          Verbose output.
 
     Assumptions:

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -8,7 +8,7 @@ import logging
 import textwrap
 
 from docopt import docopt, DocoptExit
-from schema import Schema, Use, Or, And, SchemaError
+from schema import Schema, Use, Or, SchemaError
 
 from reloadconf import ReloadConf
 

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -33,7 +33,7 @@ def validate_opts(opts):
             float(timeout)
         except ValueError:
             assert 0, "invalid timeout %r" % timeout
-        assert int(timeout) > 0, "invalid timeout %r" % timeout
+        assert float(timeout) > 0, "invalid timeout %r" % timeout
 
 
 def main(opt):

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -55,7 +55,7 @@ def main(opt):
         --wait-for-path=<file>
                          Delay start until file or directory appears on disk.
         --wait-for-sock=<host:port>
-                         Delay start until connection succeeds.
+                         Delay start until TCP connection succeeds.
         --wait-timeout=<secs>
                          Timeout for wait-* commands [default: 5].
         --debug          Verbose output.

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -128,6 +128,7 @@ def main(argv):
 
     try:
         rc = ReloadConf(**kwargs)
+
     except AssertionError as e:
         raise DocoptExit(e.args[0])
 

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -18,18 +18,57 @@ LOGGER.addHandler(logging.NullHandler())
 
 
 def host_and_port(value):
+    """
+    Parse "host:port" string into (host, port) tuple.
+
+    >>> host_and_port('host:1')
+    ('host', 1)
+    >>> host_and_port(' host:1 ')
+    ('host', 1)
+    >>> host_and_port('host:foo')
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    File "reloadconf/__main__.py", line 33, in host_and_port
+        return host.strip(), int(port.strip())
+    ValueError: invalid literal for int() with base 10: 'foo'
+    """
     host, port = value.split(':')
-    return host, int(port)
+
+    return host.strip(), int(port.strip())
 
 
 def user_and_group(value):
+    """
+    Parse "user,group" string into (user, group) tuple.
+
+    The group portion is optional in which case it will be None. Also, either
+    user or group could be integers.
+
+    >>> user_and_group('foo,bar')
+    ('foo', 'bar')
+    >>> user_and_group('foo')
+    ('foo', None)
+    >>> user_and_group('foo,1000')
+    ('foo', 1000)
+    >>> user_and_group(' 1000, 1000 ')
+    (1000, 1000)
+    """
     def _try_int(v):
         try:
             return int(v)
+
         except ValueError:
             return v
 
-    return tuple(map(_try_int, value.split(',')))
+    value = [_try_int(s.strip()) for s in value.split(',')]
+
+    if len(value) > 2:
+        raise AssertionError('Only two values accepted')
+
+    elif len(value) == 1:
+        value.append(None)
+
+    return tuple(value)
 
 
 def main(argv):

--- a/reloadconf/__main__.py
+++ b/reloadconf/__main__.py
@@ -29,7 +29,10 @@ def validate_opts(opts):
         assert int(port) < 65536, "invalid port %r" % port
     timeout = opts.get('wait_timeout')
     if timeout:
-        assert timeout.isdigit(), "invalid timeout %r" % timeout
+        try:
+            float(timeout)
+        except ValueError:
+            assert 0, "invalid timeout %r" % timeout
         assert int(timeout) > 0, "invalid timeout %r" % timeout
 
 

--- a/reloadconf/version.py
+++ b/reloadconf/version.py
@@ -1,2 +1,2 @@
 # Do not edit. See setup.py.
-__version__ = "1.1.2-1-ga00a861"
+__version__ = "1.1.15-3-g13a4b47"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ docopt
 schema
 inotify
 six
+contextlib2

--- a/tests.py
+++ b/tests.py
@@ -256,6 +256,20 @@ class TestReloadConf(TestCase):
             self.run_cli(others=['--wait-for-sock=localhost:65000',
                                  '--wait-timeout=0.1'])
 
+    def test_wait_for_sock_ok(self):
+        class Sentinal(Exception):
+            pass
+
+        def _alarm(*args):
+            raise Sentinal()
+
+        signal.signal(signal.SIGALRM, _alarm)
+        signal.alarm(1)
+
+        with self.assertRaises(Sentinal):
+            self.run_cli(others=['--wait-for-sock=google.com:80',
+                                 '--wait-timeout=3'])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests.py
+++ b/tests.py
@@ -41,7 +41,23 @@ logging.basicConfig(
 LOGGER = logging.getLogger(__name__)
 
 
-class TestReloadConf(unittest.TestCase):
+class TestCase(unittest.TestCase):
+
+    # Print a full path representation of the single unit tests
+    # being run, e.g. tests.TestReloadConf.test_fail.
+    def __str__(self):
+        mod = self.__class__.__module__
+        if mod == '__main__':
+            mod = os.path.splitext(os.path.basename(__file__))[0]
+        return "%s.%s.%s" % (
+            mod, self.__class__.__name__, self._testMethodName)
+
+    # Avoid printing docstrings.
+    def shortDescription(self):
+        return None
+
+
+class TestReloadConf(TestCase):
 
     @classmethod
     def setUp(cls):
@@ -182,25 +198,8 @@ class TestReloadConf(unittest.TestCase):
         signal.signal(signal.SIGALRM, _alarm)
         signal.alarm(2)
 
-        sysargv = sys.argv
-
-        sys.argv = [
-            'reloadconf',
-            '--watch=%s' % self.dir,
-            '--config=%s' % self.file,
-            '--command=/bin/sleep 1',
-            '--test=/bin/true',
-        ]
-
-        try:
-            try:
-                import reloadconf.__main__
-                self.fail('Should never reach this')
-            except Sentinal:
-                pass
-
-        finally:
-            sys.argv = sysargv
+        with self.assertRaises(Sentinal):
+            self.run_cli()
 
     def test_wait_timeout(self):
         with self.assertRaises(AssertionError) as exc:
@@ -212,6 +211,5 @@ class TestReloadConf(unittest.TestCase):
         self.assertEqual(exc.exception.message, "invalid timeout 'string'")
 
 
-
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,8 @@ import numbers
 
 from unittest import skipIf
 
+from docopt import DocoptExit
+
 from os.path import exists as pathexists
 from os.path import join as pathjoin
 from os.path import basename, isdir
@@ -69,6 +71,11 @@ class TestCase(unittest.TestCase):
     # Avoid printing docstrings.
     def shortDescription(self):
         return None
+
+    def assertStartsWith(self, start, text, message=None):
+        if message is None:
+            message = 'text does not start with %s' % start
+        self.assertTrue(text.startswith(start), message)
 
 
 def safe_rmpath(path):
@@ -292,13 +299,13 @@ class TestReloadConf(TestCase):
             signal.signal(signal.SIGALRM, signal.SIG_IGN)
 
     def test_wait_timeout(self):
-        with self.assertRaises(AssertionError) as exc:
+        with self.assertRaises(DocoptExit) as exc:
             self.run_cli(others=['--wait-timeout=-1'])
-        self.assertEqual(exc.exception.args[0], "invalid timeout '-1'")
+        self.assertStartsWith("Invalid timeout", exc.exception.args[0])
 
-        with self.assertRaises(AssertionError) as exc:
+        with self.assertRaises(DocoptExit) as exc:
             self.run_cli(others=['--wait-timeout=string'])
-        self.assertEqual(exc.exception.args[0], "invalid timeout 'string'")
+        self.assertStartsWith("Invalid timeout", exc.exception.args[0])
 
     def test_wait_for_path_fail(self):
         with self.assertRaises(TimeoutExpired):

--- a/tests.py
+++ b/tests.py
@@ -61,7 +61,7 @@ LOGGER = logging.getLogger(__name__)
 
 class TestTimeoutError(Exception):
     def __init__(self):
-        super().__init__('Timeout exceeded')
+        super(TestTimeoutError, self).__init__('Timeout exceeded')
 
 
 @contextlib.contextmanager
@@ -315,12 +315,14 @@ class TestReloadConf(TestCase):
     def test_wait_timeout(self):
         with timeout():
             with self.assertRaises(DocoptExit) as exc:
-                self.run_cli(others=['--wait-timeout=-1'])
+                self.run_cli(others=['--wait-timeout=-1',
+                                     '--wait-for-path=foo-bar-path'])
             self.assertStartsWith("Invalid timeout", exc.exception.args[0])
 
         with timeout():
             with self.assertRaises(DocoptExit) as exc:
-                self.run_cli(others=['--wait-timeout=string'])
+                self.run_cli(others=['--wait-timeout=string',
+                                     '--wait-for-path=foo-bar-path'])
             self.assertStartsWith("Invalid timeout", exc.exception.args[0])
 
     def test_wait_for_path_fail(self):


### PR DESCRIPTION
Introduces 3 new options to wait for files and sockets:

```
--wait-for-path=<file>
    Delay start until file or directory appears on disk.

--wait-for-sock=<host:port>
    Delay start until TCP connection succeeds.

--wait-timeout=<secs>
    Timeout for wait-* commands [default: 5].
```